### PR TITLE
Add package documentation and usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# OpenObserve Go slog writer
+
+This module provides an `io.Writer` for Go's `slog` logging framework that forwards records to an [OpenObserve](https://openobserve.ai) instance while still writing them to standard output.
+
+## Installation
+
+```bash
+go get github.com/oldbear24/openobserve-go-slog-writer
+```
+
+## Usage
+
+```go
+package main
+
+import (
+        "log/slog"
+
+        logoutput "github.com/oldbear24/openobserve-go-slog-writer"
+)
+
+func main() {
+        // Configure the writer. When enableExtenal is false, logs are only
+        // written to stdout.
+        writer := logoutput.New(true, "http://localhost:5080", "authToken", "org", "stream")
+        logger := slog.New(slog.NewJSONHandler(writer, nil))
+
+        logger.Info("hello from slog")
+
+        // Close flushes any buffered logs.
+        writer.Close()
+}
+```
+
+## Configuration
+
+- `externalUrl`: Base URL of the OpenObserve instance.
+- `authToken`: Base64 encoded credentials for Basic Authentication.
+- `externalOrganization`: Organization to send logs to.
+- `externalStream`: Stream name for logs.
+
+Logs are batched and automatically uploaded periodically or when the buffer exceeds a threshold.
+

--- a/logOutput.go
+++ b/logOutput.go
@@ -1,3 +1,5 @@
+// Package logoutput provides an io.Writer implementation that can forward
+// logs to an OpenObserve instance while still writing them to stdout.
 package logoutput
 
 import (
@@ -11,6 +13,8 @@ import (
 	"time"
 )
 
+// LogOutput implements io.Writer and buffers log entries for optional
+// delivery to an OpenObserve instance.
 type LogOutput struct {
 	enableExtenal        bool
 	externalUrl          string
@@ -22,6 +26,8 @@ type LogOutput struct {
 	lastLogUpload        time.Time
 }
 
+// Write implements io.Writer. It always writes to stdout and, when external
+// logging is enabled, queues the log entry for uploading to OpenObserve.
 func (l *LogOutput) Write(p []byte) (n int, err error) {
 	if l.enableExtenal {
 		var data []byte = make([]byte, len(p))
@@ -80,15 +86,23 @@ func (l *LogOutput) sendLogToExternalService() {
 	l.logs = make([][]byte, 0)
 }
 
+// ForceLogToExternalService forces any pending logs to be uploaded.
+// The function is currently a placeholder for future enhancements.
 func ForceLogToExternalService() {
 
 }
+
+// Close flushes any buffered logs and releases resources associated with the
+// writer.
 func (l *LogOutput) Close() {
 	if l.enableExtenal {
 		l.sendLogToExternalService()
 		close(l.logChannel)
 	}
 }
+
+// New creates a new LogOutput. When enableExtenal is true, logs are queued and
+// periodically uploaded to the provided OpenObserve endpoint.
 func New(enableExtenal bool, externalUrl, authToken, externalOrganization, externalStream string) *LogOutput {
 
 	l := &LogOutput{}


### PR DESCRIPTION
## Summary
- document package with comments for exported types and functions
- add README with installation, usage example, and configuration details

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_689b81cce86c832eb2e01c0306471707